### PR TITLE
Use 'node:' prefix for Node.js-native modules

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,5 +1,5 @@
-import http from 'http';
-import path from 'path';
+import http from 'node:http';
+import path from 'node:path';
 
 import express from 'express';
 import { engine } from 'express-handlebars';


### PR DESCRIPTION
This PR adds the `node:` prefix to Node.js native modules to make their origin and distinction from third-party packages clearer.