### PR TITLE
Preserve output upon process restart from watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "unit-test": "mocha --config test/.mocharc.json",
     "build": "webpack",
     "watch": "webpack --watch",
-    "start": "npm run watch & node --watch-path=built --watch-path=public --require source-map-support/register built/main.js"
+    "start": "npm run watch & node --watch-path=built --watch-path=public --watch-preserve-output --require source-map-support/register built/main.js"
   },
   "pre-commit": [
     "lint-check",


### PR DESCRIPTION
This PR is a follow up to https://github.com/andygout/dramatis-cms/pull/217.

It adds the [`--watch-preserve-output`](https://nodejs.org/api/cli.html#--watch-preserve-output) flag to disable the clearing of the console when watch mode restarts the process.

### References:
- [Command-line API | Node.js Documentation: `--watch-preserve-output`](https://nodejs.org/api/cli.html#--watch-preserve-output)