### PR TITLE
Use Node.js-native source maps enablement

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "unit-test": "mocha --config test/.mocharc.json",
     "build": "rollup --config",
     "watch": "rollup --config --watch",
-    "start": "npm run watch & node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --require source-map-support/register built/main.js"
+    "start": "npm run watch & node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --enable-source-maps built/main.js"
   },
   "pre-commit": [
     "lint-check",
@@ -44,8 +44,7 @@
     "redux": "4.2.1",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.4.2",
-    "serve-favicon": "2.5.0",
-    "source-map-support": "0.5.21"
+    "serve-favicon": "2.5.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.24.6",


### PR DESCRIPTION
This PR applies the Node.js-native source maps enablement (by applying the `--enable-source-maps` flag), which in turn means the `source-map-support` dependency is no longer required and can be removed.

### References:
- [Node.js v22.8.0 | Command-line API: `--enable-source-maps`](https://nodejs.org/api/cli.html#--enable-source-maps)