### PR TITLE
Use JSX automatic import transform

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
     "no-var": 2,
     "one-var": [2, "never"],
     "quotes": [2, "single"],
+    "react/react-in-jsx-scope": 0,
     "semi": 2,
     "space-before-function-paren": 2,
     "spaced-comment": 2,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,7 @@ const serverBundle = {
 		'node:url',
 		'prop-types',
 		'react',
+		'react/jsx-runtime',
 		'react-bootstrap-typeahead',
 		'react-dom/server',
 		'react-helmet',
@@ -39,6 +40,7 @@ const serverBundle = {
 	},
 	plugins: [
 		esbuild({
+			jsx: 'automatic',
 			jsxFactory: 'React.createElement',
 			jsxFragment: 'React.Fragment'
 		}),
@@ -66,7 +68,12 @@ const clientScriptsBundle = {
 		}),
 		babel({
 			babelHelpers: 'bundled',
-			presets: ['@babel/preset-react'],
+			presets: [
+				[
+					'@babel/preset-react',
+					{ runtime: 'automatic' }
+				]
+			],
 			extensions: ['.js', '.jsx']
 		}),
 		commonjs(),

--- a/src/react/AppRoutes.jsx
+++ b/src/react/AppRoutes.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
 
 import Layout from './Layout.jsx';

--- a/src/react/Layout.jsx
+++ b/src/react/Layout.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { useLocation, useMatch, useNavigate } from 'react-router-dom';

--- a/src/react/client-mount.jsx
+++ b/src/react/client-mount.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';

--- a/src/react/components/ErrorMessage.jsx
+++ b/src/react/components/ErrorMessage.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { Helmet } from 'react-helmet';
 
 import PageTitle from './PageTitle.jsx';

--- a/src/react/components/Footer.jsx
+++ b/src/react/components/Footer.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Footer = () => {
 
 	return (

--- a/src/react/components/FormattedJson.jsx
+++ b/src/react/components/FormattedJson.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const FormattedJson = props => {
 

--- a/src/react/components/Header.jsx
+++ b/src/react/components/Header.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { SearchBar } from './index.js';

--- a/src/react/components/InstanceDocumentTitle.jsx
+++ b/src/react/components/InstanceDocumentTitle.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { Helmet } from 'react-helmet';
 
 import { ACTIONS } from '../../utils/constants.js';

--- a/src/react/components/InstanceLabel.jsx
+++ b/src/react/components/InstanceLabel.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { MODEL_TO_DISPLAY_NAME_MAP } from '../../utils/constants.js';
 

--- a/src/react/components/Navigation.jsx
+++ b/src/react/components/Navigation.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 const Navigation = () => {

--- a/src/react/components/Notification.jsx
+++ b/src/react/components/Notification.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import React from 'react';
 
 import { NOTIFICATION_STATUSES } from '../../utils/constants.js';
 

--- a/src/react/components/PageTitle.jsx
+++ b/src/react/components/PageTitle.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import React from 'react';
 
 const PageTitle = props => {
 

--- a/src/react/components/SearchBar.jsx
+++ b/src/react/components/SearchBar.jsx
@@ -1,6 +1,6 @@
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "(newSelectionPrefix|paginationText|renderMenuItemChildren)" }] */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/react/components/form/ArrayItemActionButton.jsx
+++ b/src/react/components/form/ArrayItemActionButton.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const ArrayItemActionButton = props => {
 

--- a/src/react/components/form/Fieldset.jsx
+++ b/src/react/components/form/Fieldset.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const Fieldset = props => {
 

--- a/src/react/components/form/FieldsetComponent.jsx
+++ b/src/react/components/form/FieldsetComponent.jsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const FieldsetComponent = props => {
 

--- a/src/react/components/form/FormWrapper.jsx
+++ b/src/react/components/form/FormWrapper.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { capitalise } from '../../../lib/strings.js';

--- a/src/react/components/form/Input.jsx
+++ b/src/react/components/form/Input.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import React from 'react';
 
 const Input = props => {
 

--- a/src/react/components/form/InputAndErrors.jsx
+++ b/src/react/components/form/InputAndErrors.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { Input, InputErrors } from './index.js';
 

--- a/src/react/components/form/InputErrors.jsx
+++ b/src/react/components/form/InputErrors.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const InputErrors = props => {
 

--- a/src/react/components/instance-forms/AwardCeremonyForm.jsx
+++ b/src/react/components/instance-forms/AwardCeremonyForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { capitalise } from '../../../lib/strings.js';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form/index.js';

--- a/src/react/components/instance-forms/AwardForm.jsx
+++ b/src/react/components/instance-forms/AwardForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Fieldset, FormWrapper, InputAndErrors } from '../form/index.js';
 import { handleChange } from '../../utils/form.js';

--- a/src/react/components/instance-forms/CharacterForm.jsx
+++ b/src/react/components/instance-forms/CharacterForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Fieldset, FormWrapper, InputAndErrors } from '../form/index.js';
 import { handleChange } from '../../utils/form.js';

--- a/src/react/components/instance-forms/CompanyForm.jsx
+++ b/src/react/components/instance-forms/CompanyForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Fieldset, FormWrapper, InputAndErrors } from '../form/index.js';
 import { handleChange } from '../../utils/form.js';

--- a/src/react/components/instance-forms/FestivalForm.jsx
+++ b/src/react/components/instance-forms/FestivalForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form/index.js';
 import { handleChange } from '../../utils/form.js';

--- a/src/react/components/instance-forms/FestivalSeriesForm.jsx
+++ b/src/react/components/instance-forms/FestivalSeriesForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Fieldset, FormWrapper, InputAndErrors } from '../form/index.js';
 import { handleChange } from '../../utils/form.js';

--- a/src/react/components/instance-forms/MaterialForm.jsx
+++ b/src/react/components/instance-forms/MaterialForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { capitalise } from '../../../lib/strings.js';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form/index.js';

--- a/src/react/components/instance-forms/PersonForm.jsx
+++ b/src/react/components/instance-forms/PersonForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Fieldset, FormWrapper, InputAndErrors } from '../form/index.js';
 import { handleChange } from '../../utils/form.js';

--- a/src/react/components/instance-forms/ProductionForm.jsx
+++ b/src/react/components/instance-forms/ProductionForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { capitalise } from '../../../lib/strings.js';
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form/index.js';

--- a/src/react/components/instance-forms/SeasonForm.jsx
+++ b/src/react/components/instance-forms/SeasonForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Fieldset, FormWrapper, InputAndErrors } from '../form/index.js';
 import { handleChange } from '../../utils/form.js';

--- a/src/react/components/instance-forms/VenueForm.jsx
+++ b/src/react/components/instance-forms/VenueForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { ArrayItemActionButton, Fieldset, FieldsetComponent, FormWrapper, InputAndErrors } from '../form/index.js';
 import {

--- a/src/react/components/withInstancePageTitle.jsx
+++ b/src/react/components/withInstancePageTitle.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { ACTIONS } from '../../utils/constants.js';
 

--- a/src/react/pages/Home.jsx
+++ b/src/react/pages/Home.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PageTitle } from '../components/index.js';
 
 const Home = () => {

--- a/src/react/pages/NotFound.jsx
+++ b/src/react/pages/NotFound.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ErrorMessage } from '../components/index.js';
 
 const NotFound = () => {

--- a/src/react/pages/instances/Award.jsx
+++ b/src/react/pages/instances/Award.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { AwardForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/AwardCeremony.jsx
+++ b/src/react/pages/instances/AwardCeremony.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { AwardCeremonyForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/Character.jsx
+++ b/src/react/pages/instances/Character.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { CharacterForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/Company.jsx
+++ b/src/react/pages/instances/Company.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { CompanyForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/Festival.jsx
+++ b/src/react/pages/instances/Festival.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { FestivalForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/FestivalSeries.jsx
+++ b/src/react/pages/instances/FestivalSeries.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { FestivalSeriesForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { MaterialForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { PersonForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ProductionForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/Season.jsx
+++ b/src/react/pages/instances/Season.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { SeasonForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/instances/Venue.jsx
+++ b/src/react/pages/instances/Venue.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { VenueForm } from '../../components/instance-forms/index.js';

--- a/src/react/pages/lists/AwardCeremonies.jsx
+++ b/src/react/pages/lists/AwardCeremonies.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/Awards.jsx
+++ b/src/react/pages/lists/Awards.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/Characters.jsx
+++ b/src/react/pages/lists/Characters.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/Companies.jsx
+++ b/src/react/pages/lists/Companies.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/FestivalSerieses.jsx
+++ b/src/react/pages/lists/FestivalSerieses.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/Festivals.jsx
+++ b/src/react/pages/lists/Festivals.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/Materials.jsx
+++ b/src/react/pages/lists/Materials.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/People.jsx
+++ b/src/react/pages/lists/People.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/Productions.jsx
+++ b/src/react/pages/lists/Productions.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/Seasons.jsx
+++ b/src/react/pages/lists/Seasons.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/lists/Venues.jsx
+++ b/src/react/pages/lists/Venues.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../wrappers/index.js';

--- a/src/react/react-html.jsx
+++ b/src/react/react-html.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Provider } from 'react-redux';
 import { StaticRouter } from 'react-router-dom/server.js';

--- a/src/react/wrappers/InstanceWrapper.jsx
+++ b/src/react/wrappers/InstanceWrapper.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import getDifferentiatorSuffix from '../../lib/get-differentiator-suffix.js';
 import {

--- a/src/react/wrappers/ListWrapper.jsx
+++ b/src/react/wrappers/ListWrapper.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { FormattedJson, PageTitle } from '../components/index.js';
 


### PR DESCRIPTION
When switching to Rollup.js in PR https://github.com/andygout/dramatis-cms/pull/222, this [DEV Community article](https://dev.to/vvkkumar06/setup-rollup-for-react-library-project-2024-3jea) mentioned that it is possible to:
> [eliminate] the need for a global React import in each file that uses JSX

This is achieved in the rollup.config.js file by modifying the value of the `presets` property in the object passed as an argument to the function provided by `@rollup/plugin-babel` (and some equivalent changes for the server bundle).

### References:
- [DEV Community: Setup rollup for React Library project - 2024](https://dev.to/vvkkumar06/setup-rollup-for-react-library-project-2024-3jea) by Vivek Kumar
  - > **What is runtime: "automatic ?**
     > The "automatic" runtime in Babel refers to the new JSX transform introduced in Babel 17. This transform changes how JSX is compiled, and it eliminates the need for a global React import in each file that uses JSX.
     > With the introduction of the automatic runtime in Babel 17, the need for the explicit React import is eliminated.
- [React Blog: Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
- [npm: rollup-plugin-esbuild](https://www.npmjs.com/package/rollup-plugin-esbuild#usage)
  - Demonstrates the `jsx` property
- [GitHub: evanw / esbuild — Issue: Support jsx automatic runtime — comment from evanw](https://github.com/evanw/esbuild/issues/334)
- [esbuild: Content Types — Auto-import for JSX](https://esbuild.github.io/content-types/#auto-import-for-jsx)
  - Demonstrates that `'automatic'` is a valid argument for the `jsx` property