### PR TITLE
Resolve Rollup 'Circular dependencies' warning

### DIFF
--- a/src/react/components/Header.jsx
+++ b/src/react/components/Header.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 
-import { SearchBar } from './index.js';
+import SearchBar from './SearchBar.jsx';
 
 const Header = () => {
 

--- a/src/react/components/form/InputAndErrors.jsx
+++ b/src/react/components/form/InputAndErrors.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { Input, InputErrors } from './index.js';
+import Input from './Input.jsx';
+import InputErrors from './InputErrors.jsx';
 
 const InputAndErrors = props => {
 


### PR DESCRIPTION
The `npm run build` command (which triggers the Rollup build task) currently outputs the below warning:

> src/server/app.js → built/main.js...
> (!) Circular dependencies
> src/react/components/index.js -> src/react/components/Header.jsx -> src/react/components/index.js
> src/react/components/form/index.js -> src/react/components/form/InputAndErrors.jsx -> src/react/components/form/index.js
> created built/main.js in 592ms

This PR resolves those circular dependencies.