### PR TITLE
Upgrade Rollup packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "unit-test": "mocha --config test/.mocharc.json",
     "build": "rollup --config",
     "watch": "rollup --config --watch",
-    "start": "npm run watch & node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --enable-source-maps built/main.js"
+    "node": "node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --enable-source-maps built/main.js" ,
+    "start": "concurrently --names \"watch,node\" --prefixColors \"yellow,green\" \"npm run watch\" \"npm run node\""
   },
   "pre-commit": [
     "lint-check",
@@ -49,10 +50,11 @@
   "devDependencies": {
     "@babel/preset-react": "7.24.6",
     "@rollup/plugin-babel": "6.0.4",
-    "@rollup/plugin-commonjs": "26.0.1",
-    "@rollup/plugin-node-resolve": "15.2.3",
-    "@rollup/plugin-replace": "5.0.7",
+    "@rollup/plugin-commonjs": "28.0.1",
+    "@rollup/plugin-node-resolve": "15.3.0",
+    "@rollup/plugin-replace": "6.0.1",
     "chai": "4.4.1",
+    "concurrently": "9.1.0",
     "eslint": "8.57.0",
     "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-no-only-tests": "3.1.0",
@@ -60,7 +62,7 @@
     "lintspaces-cli": "0.8.0",
     "mocha": "10.4.0",
     "pre-commit": "1.2.2",
-    "rollup": "4.19.1",
+    "rollup": "4.28.1",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-esbuild": "6.1.1",
     "rollup-plugin-scss": "4.0.0",


### PR DESCRIPTION
This PR upgrades the packages related to Rollup.js to their current latest versions.

[rollup](https://www.npmjs.com/package/rollup) v4.21.1 includes the following PR: https://github.com/rollup/rollup/pull/5619

The [changes made in that PR to `cli/run/watch-cli.ts`](https://github.com/rollup/rollup/pull/5619/files#diff-a447f91d66f095e09b94b97e5645a141e87cfcc19af6e8cac908b4ab5471cdae) means that this repo's `start` script (below) will no longer work as intended (if you manually undo those specific changes but keep all other changes introduced in v4.21.1 then it will continue to work).

```bash
"npm run watch & node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --enable-source-maps built/main.js"
```

Note:
- `&&` (double ampersand) for sequential execution
- `&` (single ampersand) for parallel execution

### Single ampersand (`&`)
The `watch` script fails to be effective:

```bash
$ npm start

> dramatis-cms@0.0.0 start
> npm run watch & node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --enable-source-maps built/main.js


> dramatis-cms@0.0.0 watch
> rollup --config --watch

Listening on port 3001
```

Owing to the changes made to `cli/run/watch-cli.ts`, this may be due to:

> 1. The `npm run watch` command is started as a background process with `&` and might not be running as expected in the background.
> 2. If `npm run watch` involves setting up processes like file watching or starting a server, they might not be initialized properly because it's running in the background and not interacting with the rest of the process in the expected way.
> 3. It's possible that the `node` command starts executing before `npm run watch` has had a chance to fully initialize.

Ref. ChatGPT

### Double ampersand (`&&`)
The `node` aspect of the `start` script (i.e. what comes after the double ampersand) is not invoked:

```bash
$ npm start

> dramatis-cms@0.0.0 start
> npm run watch && node --watch-path=built --watch-preserve-output --watch-path=public --watch-preserve-output --enable-source-maps built/main.js


> dramatis-cms@0.0.0 watch
> rollup --config --watch

rollup v4.21.1
bundles src/server/app.js → built/main.js...
created built/main.js in 236ms
bundles src/react/client-mount.jsx → public/main.js...
[BABEL] Note: The code generator has deoptimised the styling of /{path}/dramatis-cms/node_modules/react-dom/cjs/react-dom.development.js as it exceeds the max of 500KB.
created public/main.js in 3.5s
bundles src/client/stylesheets/index.scss → public...
(!) Generated an empty chunk
"index"
created public in 231ms

[2024-12-15 09:12:40] waiting for changes...
```

This is because the `watch` script starts a long-running process which is not considered manually completed until it has been stopped manually by the user. This was also the case prior to upgrading [rollup](https://www.npmjs.com/package/rollup) to v4.21.1.

---

The suggestion at this point is to use the [concurrently](https://www.npmjs.com/package/concurrently) package which runs multiple commands in parallel.

This PR implements this approach, extracting the `node` aspect of the `start` script into its own script for clarity, and colour-coding and naming (based on their script name) prefixes in the output logs to make clear to which command they correspond:

![Screenshot 2024-12-15 at 09 25 10](https://github.com/user-attachments/assets/33e32077-e14a-47b6-a634-06eb5994d125)

### New dev dependencies:
- [concurrently](https://www.npmjs.com/package/concurrently)