### PR TITLE
Upgrade Redux packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "react-bootstrap-typeahead": "6.3.2",
     "react-dom": "18.3.1",
     "react-helmet": "6.1.0",
-    "react-redux": "8.1.3",
+    "react-redux": "9.2.0",
     "react-router-dom": "6.23.1",
-    "redux": "4.2.1",
+    "redux": "5.0.1",
     "redux-logger": "3.0.6",
-    "redux-thunk": "2.4.2",
+    "redux-thunk": "3.1.0",
     "serve-favicon": "2.5.0"
   },
   "devDependencies": {

--- a/src/react/client-mount.jsx
+++ b/src/react/client-mount.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { applyMiddleware, createStore, combineReducers } from 'redux';
 import { createLogger } from 'redux-logger';
-import thunkMiddleware from 'redux-thunk';
+import { thunk as thunkMiddleware } from 'redux-thunk';
 
 import AppRoutes from './AppRoutes.jsx';
 import reducers from '../redux/reducers/index.js';

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { Helmet } from 'react-helmet';
 import { matchPath } from 'react-router-dom';
 import { applyMiddleware, createStore, combineReducers } from 'redux';
-import thunkMiddleware from 'redux-thunk';
+import { thunk as thunkMiddleware } from 'redux-thunk';
 
 import getReactHtml from '../react/react-html.jsx';
 import reducers from '../redux/reducers/index.js';
@@ -13,7 +13,7 @@ const router = new Router();
 const store = createStore(
 	combineReducers(reducers),
 	{},
-	applyMiddleware(...[thunkMiddleware.default])
+	applyMiddleware(...[thunkMiddleware])
 );
 
 router.get('*', async (request, response, next) => {


### PR DESCRIPTION
This PR upgrades all Redux-related packages to their current latest version.

These major upgrades were far easier to apply having first migrated this repo to use Node.js-native ECMAScript modules (as done in https://github.com/andygout/dramatis-cms/pull/222).

- [react-redux v9.0.0](https://github.com/reduxjs/react-redux/releases/tag/v9.0.0)
- [redux v5.0.0](https://github.com/reduxjs/redux/releases/tag/v5.0.0)
- [redux-thunk v3.1.0](https://github.com/reduxjs/redux-thunk/releases/tag/v3.1.0)

Each of these major releases includes:
> Updates the packaging for better ESM/CJS compatibility and modernizes the build output

They also all have the same **ESM/CJS Package Compatibility** section:
> The biggest theme of the Redux v5 and RTK 2.0 releases is trying to get "true" ESM package publishing compatibility in place, while still supporting CJS in the published package.
>
> **The primary build artifact is now an ESM file, `dist/redux.mjs`**. Most build tools should pick this up. There's also a CJS artifact, and a second copy of the ESM file named `redux.legacy-esm.js` to support Webpack 4 (which does not recognize the `exports` field in `package.json`). Additionally, all of the build artifacts now live under `./dist/` in the published package.