### PR TITLE
Upgrade chai 4.4.1 -> 5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@rollup/plugin-commonjs": "28.0.1",
     "@rollup/plugin-node-resolve": "15.3.0",
     "@rollup/plugin-replace": "6.0.1",
-    "chai": "4.4.1",
+    "chai": "5.1.2",
     "concurrently": "9.1.0",
     "eslint": "8.57.0",
     "eslint-plugin-mocha": "^10.4.3",


### PR DESCRIPTION
This PR upgrades [chai](https://www.npmjs.com/package/chai) to its current latest version.

This major upgrade was dependent on first migrating this repo to use Node.js-native ECMAScript modules (as done in https://github.com/andygout/dramatis-cms/pull/222).

Prior to then, the following error message would display:
> Chai now only supports EcmaScript Modules (ESM). This means your tests will need to either have import {...} from 'chai' or import('chai'). require('chai') will cause failures in nodejs. If you're using ESM and seeing failures, it may be due to a bundler or transpiler which is incorrectly converting import statements into require calls.

Mentioned as part of this major release:
- [chai v5.0.0](https://github.com/chaijs/chai/releases/tag/v5.0.0)
  - > Chai now only supports EcmaScript Modules (ESM). This means your tests will need to either have `import {...} from 'chai'` or `import('chai')`. `require('chai')` will cause failures in nodejs. If you're using ESM and seeing failures, it may be due to a bundler or transpiler which is incorrectly converting import statements into require calls.