### PR TITLE
Remove redundant eslint no-unused-vars argsIgnorePattern comment

### DIFF
--- a/src/react/components/SearchBar.jsx
+++ b/src/react/components/SearchBar.jsx
@@ -1,5 +1,3 @@
-/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "(newSelectionPrefix|paginationText|renderMenuItemChildren)" }] */
-
 import { useState } from 'react';
 import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead';
 import { useNavigate } from 'react-router-dom';


### PR DESCRIPTION
This PR removes a redundant eslint no-unused-vars argsIgnorePattern comment.