### PR TITLE
Revise ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,7 @@ export default [
 			'comma-dangle': 2,
 			eqeqeq: 2,
 			'guard-for-in': 2,
-			'new-cap': 0,
+			'new-cap': 2,
 			'no-caller': 2,
 			'no-console': 2,
 			'no-extend-native': 2,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url); // eslint-disable-line no-underscore-dangle
+const __dirname = path.dirname(__filename); // eslint-disable-line no-underscore-dangle
 
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
@@ -56,7 +56,7 @@ export default [
 			'no-multi-spaces': 2,
 			'no-multiple-empty-lines': [2, { max: 1 }],
 			'no-undef': 2,
-			'no-underscore-dangle': 0,
+			'no-underscore-dangle': 2,
 			'no-unused-vars': 2,
 			'no-var': 2,
 			'one-var': [2, 'never'],

--- a/src/react/components/withInstancePageTitle.jsx
+++ b/src/react/components/withInstancePageTitle.jsx
@@ -4,7 +4,7 @@ import { ACTIONS } from '../../utils/constants.js';
 
 const withInstancePageTitle = PageTitle => {
 
-	const _InstancePageTitle = props => {
+	const _InstancePageTitle = props => { // eslint-disable-line no-underscore-dangle
 
 		const { name, modelDisplayName, differentiatorSuffix, formAction } = props;
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -2,8 +2,8 @@ import http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url); // eslint-disable-line no-underscore-dangle
+const __dirname = path.dirname(__filename); // eslint-disable-line no-underscore-dangle
 
 import express from 'express';
 import { engine } from 'express-handlebars';


### PR DESCRIPTION
This PR revises a couple of ESLint rules to provide consistency with the levels applied to the same rules in the [`eslint.config.js`](https://github.com/andygout/dramatis-api/blob/cbf1563d83aa24cef80b72acbfdcaaa1c99b3677/eslint.config.js) file in [dramatis-api](https://github.com/andygout/dramatis-api).