### PR TITLE
React-Redux: Migrating connect to hooks

### DIFF
--- a/src/react/Layout.jsx
+++ b/src/react/Layout.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { ErrorMessage, Footer, Header, Navigation, Notification, ScrollToTop } from './components/index.js';
@@ -10,14 +10,20 @@ import { notificationActivated } from '../redux/actions/index.js';
 
 const Layout = props => {
 
-	const { documentTitle, error, notification, redirect, children } = props;
+	const { documentTitle, children } = props;
+
+	const dispatch = useDispatch();
+
+	const error = useSelector(state => state.error);
+	const notification = useSelector(state => state.notification);
+	const redirect = useSelector(state => state.redirect);
 
 	const location = useLocation();
 	const navigate = useNavigate();
 
 	useEffect(() => {
 
-		const { deactivateError, deactivateNotification, dispatch } = props;
+		const { deactivateError, deactivateNotification } = props;
 
 		if (deactivateError) dispatch(deactivateError());
 
@@ -97,19 +103,9 @@ const Layout = props => {
 
 Layout.propTypes = {
 	documentTitle: PropTypes.func.isRequired,
-	deactivateError: PropTypes.func.isRequired,
+	deactivateError: PropTypes.func,
 	deactivateNotification: PropTypes.func.isRequired,
-	dispatch: PropTypes.func.isRequired,
-	error: PropTypes.object.isRequired,
-	notification: PropTypes.object.isRequired,
-	redirect: PropTypes.object.isRequired,
 	children: PropTypes.node.isRequired
 };
 
-const mapStateToProps = state => ({
-	error: state.error,
-	notification: state.notification,
-	redirect: state.redirect
-});
-
-export default connect(mapStateToProps)(Layout);
+export default Layout;


### PR DESCRIPTION
This PR implements the steps described in: [Redux: Migrating to Modern Redux > Modernizing React Components with React-Redux > Migrating `connect` to Hooks](https://redux.js.org/usage/migrating-to-modern-redux#migrating-connect-to-hooks).

### References:
- [Redux: Migrating to Modern Redux > Modernizing React Components with React-Redux > Migrating `connect` to Hooks](https://redux.js.org/usage/migrating-to-modern-redux#migrating-connect-to-hooks)