### PR TITLE
Replace react-router-dom with react-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "18.3.1",
     "react-helmet": "6.1.0",
     "react-redux": "9.2.0",
-    "react-router-dom": "6.23.1",
+    "react-router": "7.1.3",
     "redux-logger": "3.0.6",
     "serve-favicon": "2.5.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,8 +32,7 @@ const serverBundle = {
 		'react-dom/server',
 		'react-helmet',
 		'react-redux',
-		'react-router-dom',
-		'react-router-dom/server.js',
+		'react-router',
 		'serve-favicon'
 	],
 	watch: {

--- a/src/react/AppRoutes.jsx
+++ b/src/react/AppRoutes.jsx
@@ -1,4 +1,4 @@
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router';
 
 import Layout from './Layout.jsx';
 import routes from './routes.js';

--- a/src/react/Layout.jsx
+++ b/src/react/Layout.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { ErrorMessage, Footer, Header, Navigation, Notification, ScrollToTop } from './components/index.js';
 import { deactivateRedirect } from '../redux/action-handlers/redirect.js';

--- a/src/react/client-mount.jsx
+++ b/src/react/client-mount.jsx
@@ -1,7 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { hydrateRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import reduxLoggerMiddleware from 'redux-logger';
 
 import AppRoutes from './AppRoutes.jsx';

--- a/src/react/components/Header.jsx
+++ b/src/react/components/Header.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import SearchBar from './SearchBar.jsx';
 

--- a/src/react/components/Navigation.jsx
+++ b/src/react/components/Navigation.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 const Navigation = () => {
 

--- a/src/react/components/SearchBar.jsx
+++ b/src/react/components/SearchBar.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { MODEL_TO_DISPLAY_NAME_MAP, MODEL_TO_ROUTE_MAP } from '../../utils/constants.js';
 

--- a/src/react/pages/instances/Award.jsx
+++ b/src/react/pages/instances/Award.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { AwardForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/AwardCeremony.jsx
+++ b/src/react/pages/instances/AwardCeremony.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { AwardCeremonyForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/Character.jsx
+++ b/src/react/pages/instances/Character.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { CharacterForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/Company.jsx
+++ b/src/react/pages/instances/Company.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { CompanyForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/Festival.jsx
+++ b/src/react/pages/instances/Festival.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { FestivalForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/FestivalSeries.jsx
+++ b/src/react/pages/instances/FestivalSeries.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { FestivalSeriesForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { MaterialForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { PersonForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { ProductionForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/Season.jsx
+++ b/src/react/pages/instances/Season.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { SeasonForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/pages/instances/Venue.jsx
+++ b/src/react/pages/instances/Venue.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { VenueForm } from '../../components/instance-forms/index.js';
 import { InstanceWrapper } from '../../wrappers/index.js';

--- a/src/react/react-html.jsx
+++ b/src/react/react-html.jsx
@@ -1,6 +1,6 @@
 import { renderToString } from 'react-dom/server';
 import { Provider } from 'react-redux';
-import { StaticRouter } from 'react-router-dom/server.js';
+import { StaticRouter } from 'react-router';
 
 import AppRoutes from './AppRoutes.jsx';
 


### PR DESCRIPTION
This PR replaces [react-router-dom](https://www.npmjs.com/package/react-router-dom) with [react-router](https://www.npmjs.com/package/react-router) as described by this migration guide: [React Router: Upgrading from v6](https://reactrouter.com/upgrading/v6)

### References:
- [React Router: Upgrading from v6](https://reactrouter.com/upgrading/v6)

### New dependencies:
- [react-router](https://www.npmjs.com/package/react-router)