### PR TITLE
Force data refetch on component mount

### DIFF
--- a/src/redux/slices/api.js
+++ b/src/redux/slices/api.js
@@ -266,6 +266,7 @@ const transformGetResponse = (response, meta, queryUuidArg) => {
 
 export const api = createApi({
 	baseQuery,
+	refetchOnMountOrArgChange: true,
 	endpoints: build => ({
 		getAwards: build.query({
 			query: () => getInstancesQuery(PLURALISED_MODELS.AWARDS)


### PR DESCRIPTION
This PR uses `refetchOnMountOrArgChange` to force a refetch of data on component mount.

This is required to fix the following user experience:

1. Visit `/venues/new`:
![venues-new](https://github.com/user-attachments/assets/9f810725-eb45-442a-85c9-1884b7093249)

2. Leave the **name** field empty (so that it will cause a validation error), enter a value into the **differentiator** field, then press the "Create" button:
![venues-new-with-error](https://github.com/user-attachments/assets/1fafc0e9-f231-472d-8305-2acd6a968d6e)

3. Enter a value into the **Sub-venues: Venue name** field:
![venues-new-with-error-and-additional-data](https://github.com/user-attachments/assets/b4ac071f-5c99-41a9-9100-7a84e93a8228)

4. Use the navigation links to enter any other page (e.g. home page):
![home](https://github.com/user-attachments/assets/50def36e-efee-456c-8a8f-9c5bde9d9c38)

5. Use the navigation link to revisit `venues/new`:

### Before
The data that populated the form after the attempt to create the new venue (i.e. clicking the "Create" button) persists but any other data entered into the form after that point has been removed.

![venues-new-revisited](https://github.com/user-attachments/assets/b15b10d9-f5d6-46e2-ab69-1b1b74d002b8)

---

### After
All fields in the form are wiped blank.

![venues-new](https://github.com/user-attachments/assets/9f810725-eb45-442a-85c9-1884b7093249)

---

In the current scenario, the data found in the form is confusing as it is residual but only to a specific point and excludes any changes made thereafter.

An alternate fix would be to ensure that when revisiting the form it retains the latest data that was entered as well, but this would require updating the logic to update the state of form data whenever any value in any field is updated.

The choice has been to wipe all fields and allow this user journey as a means to clean the slate of the form for a new model, which was the existing behaviour before switching to Redux Toolkit.

---

### References:
- [Redix Toolkit: Cache Behavior — Encouraging re-fetching with `refetchOnMountOrArgChange`](https://redux-toolkit.js.org/rtk-query/usage/cache-behavior#encouraging-re-fetching-with-refetchonmountorargchange)