### PR TITLE
Fix notification bug

### DIFF
--- a/src/react/Layout.jsx
+++ b/src/react/Layout.jsx
@@ -29,7 +29,7 @@ const Layout = props => {
 
 		if (deactivateNotification) dispatch(deactivateNotification());
 
-		if (location.state?.isRedirectActive) {
+		if (redirect.isActive) {
 
 			dispatch(deactivateRedirect());
 
@@ -45,7 +45,6 @@ const Layout = props => {
 
 			const redirectOptions = {
 				state: {
-					isRedirectActive: true,
 					notification: redirect.notification
 				}
 			};


### PR DESCRIPTION
This PR fixes the below bug by removing the `isRedirectActive` property from the client-side routing state (provided by React Router) and instead using the `redirect` property from the Redux state (provided by React Redux).

The underlying issue was that the `isRedirectActive` property from the client-side routing state is persistent, meaning that when the page is refreshed it still evaluated to `true` while `redirect.isActive` is deactivated (i.e. reset to `false`) once the redirect has completed.

1. Create an instance
<img width="662" alt="create" src="https://github.com/user-attachments/assets/ee458832-72c2-443d-8913-62ab18aee212" />

---

2. Update the instance
<img width="661" alt="update" src="https://github.com/user-attachments/assets/dd028dbc-0321-456c-a2cc-1494a5e87b74" />

---

3. Press refresh
- `location.state.isRedirectActive` is `true`
- `redirect.isActive` is `false`

### Before — misleading notification is present
Uses `location.state.isRedirectActive` (`true`) as the condition for whether to activate the notification

<img width="660" alt="refresh-before" src="https://github.com/user-attachments/assets/e660a421-9b33-472a-bf7c-c5bfd4fca38c" />

### After — no notification is present, as required
Uses `redirect.isActive` (`false`) as the condition for whether to activate the notification

<img width="662" alt="refresh-after" src="https://github.com/user-attachments/assets/735ac48d-c44b-43a0-819b-cabaf4478337" />

---

### References:
- [React Router API Reference: NavigateOptions](https://api.reactrouter.com/v7/interfaces/react_router.NavigateOptions.html)