### PR TITLE
Upgrade express 4.21.2 -> 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@reduxjs/toolkit": "2.9.0",
     "bootstrap": "5.3.8",
     "classnames": "2.5.1",
-    "express": "4.21.2",
+    "express": "5.1.0",
     "express-handlebars": "8.0.3",
     "express-session": "1.18.2",
     "morgan": "1.10.1",

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -13,7 +13,7 @@ const store = configureStore({
 	middleware: getDefaultMiddleware => getDefaultMiddleware().concat(api.middleware)
 });
 
-router.get('*', async (request, response, next) => {
+router.use(async (request, response, next) => {
 
 	try {
 


### PR DESCRIPTION
This PR upgrades [express](https://www.npmjs.com/package/express) from v4.21.2 to v5.1.0.

The below change in `src/router.js` is for a 404 status response: a catch-all middleware with no path.

```diff
- router.get('*', (request, response, next) => response.sendStatus(404));
+ router.use((request, response) => response.sendStatus(404));
```

Without this change will result in an error like this:
```
/{path}/node_modules/path-to-regexp/dist/index.js:96 throw new PathError(Missing parameter name at index ${index}, str); ^

PathError [TypeError]: Missing parameter name at index 1: *; visit https://git.new/pathToRegexpError for info
at name (/{path}/node_modules/path-to-regexp/dist/index.js:96:19)
at parse (/{path}/node_modules/path-to-regexp/dist/index.js:113:68)
at pathToRegexp (/{path}/node_modules/path-to-regexp/dist/index.js:267:58)
at Object.match (/{path}/node_modules/path-to-regexp/dist/index.js:237:30)
at matcher (/{path}/node_modules/router/lib/layer.js:86:23)
at new Layer (/{path}/node_modules/router/lib/layer.js:93:62) 
at router.route (/{path}/node_modules/router/index.js:428:17)
at Router.<computed> [as get] (/{path}/node_modules/router/index.js:447:24)
at file:///{path}/src/router.js:112:8
at ModuleJob.run
(node:internal/modules/esm/module_job:371:25) {
	originalPath: '*' 
}
```

### References:
- [Introducing Express v5: A New Era for the Node.js Framework](https://expressjs.com/2024/10/15/v5-release.html)
- [Migrating to Express 5](https://expressjs.com/en/guide/migrating-5)