### PR TITLE
Upgrade sass 1.77.4 -> 1.93.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "rollup-plugin-esbuild": "6.2.1",
     "rollup-plugin-scss": "4.0.1",
     "rollup-plugin-watch-globs": "2.0.1",
-    "sass": "1.77.4"
+    "sass": "1.93.2"
   }
 }


### PR DESCRIPTION
This upgrades sass to the current latest version.

This results in the below warnings when running `npm run build` or when a build is triggered when the server is running owing to code changes.

This will be addressed in a subsequent PR.

```
src/client/stylesheets/index.scss → public...
Deprecation Warning [legacy-js-api]: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/legacy-js-api

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
17 │ @import 'react-bootstrap-typeahead/css/Typeahead';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stdin 17:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
18 │ @import 'react-bootstrap-typeahead/css/Typeahead.bs5';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stdin 18:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
21 │ @import 'bootstrap/scss/functions';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stdin 21:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
29 │ @import 'bootstrap/scss/variables';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stdin 29:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
30 │ @import 'bootstrap/scss/maps';
   │         ^^^^^^^^^^^^^^^^^^^^^
   ╵
    stdin 30:9  root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.mix instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
207 │   @return mix(white, $color, $weight);
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 207:11  tint-color()
    node_modules/bootstrap/scss/_variables.scss 79:12   @import
    stdin 29:9                                          root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.mix instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
212 │   @return mix(black, $color, $weight);
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 212:11  shade-color()
    node_modules/bootstrap/scss/_variables.scss 84:12   @import
    stdin 29:9                                          root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.mix instead.

More info and automated migrator: https://sass-lang.com/d/import

    ╷
342 │ $light-bg-subtle:         mix($gray-100, $white) !default;
    │                           ^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_variables.scss 342:27  @import
    stdin 29:9                                          root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use math.unit instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
11 │     @if $prev-num == null or unit($num) == "%" or unit($prev-num) == "%" {
   │                              ^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/_functions.scss 11:30  -assert-ascending()
    node_modules/bootstrap/scss/_variables.scss 494:1  @import
    stdin 29:9                                         root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use math.unit instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
11 │     @if $prev-num == null or unit($num) == "%" or unit($prev-num) == "%" {
   │                                                   ^^^^^^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/_functions.scss 11:51  -assert-ascending()
    node_modules/bootstrap/scss/_variables.scss 494:1  @import
    stdin 29:9                                         root stylesheet

Deprecation Warning [color-functions]: red() is deprecated. Suggestion:

color.channel($color, "red", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
185 │     "r": red($color),
    │          ^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 185:10  luminance()
    node_modules/bootstrap/scss/_functions.scss 174:8   contrast-ratio()
    node_modules/bootstrap/scss/_functions.scss 159:22  color-contrast()
    node_modules/bootstrap/scss/_variables.scss 846:42  @import
    stdin 29:9                                          root stylesheet

Deprecation Warning [color-functions]: green() is deprecated. Suggestion:

color.channel($color, "green", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
186 │     "g": green($color),
    │          ^^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 186:10  luminance()
    node_modules/bootstrap/scss/_functions.scss 174:8   contrast-ratio()
    node_modules/bootstrap/scss/_functions.scss 159:22  color-contrast()
    node_modules/bootstrap/scss/_variables.scss 846:42  @import
    stdin 29:9                                          root stylesheet

Deprecation Warning [color-functions]: blue() is deprecated. Suggestion:

color.channel($color, "blue", $space: rgb)

More info: https://sass-lang.com/d/color-functions

    ╷
187 │     "b": blue($color)
    │          ^^^^^^^^^^^^
    ╵
    node_modules/bootstrap/scss/_functions.scss 187:10  luminance()
    node_modules/bootstrap/scss/_functions.scss 174:8   contrast-ratio()
    node_modules/bootstrap/scss/_functions.scss 159:22  color-contrast()
    node_modules/bootstrap/scss/_variables.scss 846:42  @import
    stdin 29:9                                          root stylesheet

Deprecation Warning [color-functions]: red() is deprecated. Suggestion:

color.channel($color, "red", $space: rgb)

More info: https://sass-lang.com/d/color-functions

   ╷
37 │   @return red($value), green($value), blue($value);
   │           ^^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/_functions.scss 37:11   to-rgb()
    node_modules/bootstrap/scss/_variables.scss 846:31  @import
    stdin 29:9                                          root stylesheet

Deprecation Warning [color-functions]: green() is deprecated. Suggestion:

color.channel($color, "green", $space: rgb)

More info: https://sass-lang.com/d/color-functions

   ╷
37 │   @return red($value), green($value), blue($value);
   │                        ^^^^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/_functions.scss 37:24   to-rgb()
    node_modules/bootstrap/scss/_variables.scss 846:31  @import
    stdin 29:9                                          root stylesheet

Warning: 103 repetitive deprecation warnings omitted.
```